### PR TITLE
Add Node.js SQLite backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_app/database.sqlite
+node_app/*.sqlite

--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# Node.js Mapping App
+
+This simple Node.js application provides a backend service that uses an SQLite database. The database contains tables for user field mappings and option mappings. The service exposes an HTTP endpoint to return a JSON structure derived from the mapping tables.
+
+## Setup
+
+No external Node packages are required. The application relies on the `sqlite3` command line tool that is available in the environment.
+
+1. Navigate to `node_app` directory:
+   ```bash
+   cd node_app
+   ```
+2. Start the server:
+   ```bash
+   node index.js
+   ```
+   The server listens on port `3000` by default.
+
+## Endpoint
+
+- `GET /mapping` – Returns a JSON payload with the field map and translation map derived from the database tables.
+
+## Database
+
+On startup the application creates the following tables in `database.sqlite` if they do not already exist:
+
+- `src_user_fields`
+- `trg_user_fields`
+- `src_user_options`
+- `trg_user_options`
+- `mapping_user_fields`
+- `mapping_user_fields_options`
+
+You can populate these tables using the `sqlite3` command line or any SQLite tool. The `/mapping` endpoint builds JSON based on the data in `mapping_user_fields` and `mapping_user_fields_options`.
+

--- a/node_app/db.js
+++ b/node_app/db.js
@@ -1,0 +1,64 @@
+const { spawnSync } = require('child_process');
+const path = require('path');
+
+const DB_FILE = path.join(__dirname, 'database.sqlite');
+
+function execSql(sql, json = false) {
+  const args = [];
+  if (json) {
+    args.push('-json', '-header');
+  }
+  args.push(DB_FILE, sql);
+  const result = spawnSync('sqlite3', args, { encoding: 'utf8' });
+  if (result.error) throw result.error;
+  if (result.status !== 0) throw new Error(result.stderr);
+  return json ? JSON.parse(result.stdout || '[]') : result.stdout;
+}
+
+function init() {
+  execSql(`CREATE TABLE IF NOT EXISTS src_user_fields (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT,
+    field_key TEXT,
+    data_type TEXT,
+    field_type TEXT
+  );`);
+
+  execSql(`CREATE TABLE IF NOT EXISTS trg_user_fields (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT,
+    field_key TEXT,
+    data_type TEXT,
+    field_type TEXT
+  );`);
+
+  execSql(`CREATE TABLE IF NOT EXISTS src_user_options (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    option_values TEXT,
+    option_key TEXT,
+    parent_key TEXT
+  );`);
+
+  execSql(`CREATE TABLE IF NOT EXISTS trg_user_options (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    option_values TEXT,
+    option_key TEXT,
+    parent_key TEXT
+  );`);
+
+  execSql(`CREATE TABLE IF NOT EXISTS mapping_user_fields (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    src_field_key TEXT,
+    trg_field_key TEXT
+  );`);
+
+  execSql(`CREATE TABLE IF NOT EXISTS mapping_user_fields_options (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    src_value_key TEXT,
+    trg_value_key TEXT,
+    src_field TEXT,
+    trg_field TEXT
+  );`);
+}
+
+module.exports = { execSql, init, DB_FILE };

--- a/node_app/index.js
+++ b/node_app/index.js
@@ -1,0 +1,24 @@
+const http = require('http');
+const { init } = require('./db');
+const { buildMapping } = require('./mappingService');
+
+init();
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'GET' && req.url === '/mapping') {
+    try {
+      const data = buildMapping();
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(data, null, 2));
+    } catch (err) {
+      res.writeHead(500, { 'Content-Type': 'text/plain' });
+      res.end(err.message);
+    }
+  } else {
+    res.writeHead(404, { 'Content-Type': 'text/plain' });
+    res.end('Not found');
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/node_app/mappingService.js
+++ b/node_app/mappingService.js
@@ -1,0 +1,40 @@
+const { execSql } = require('./db');
+
+function buildMapping() {
+  const fieldRows = execSql(
+    `SELECT m.src_field_key, m.trg_field_key, s.field_type
+     FROM mapping_user_fields m
+     LEFT JOIN src_user_fields s ON m.src_field_key = s.field_key`,
+    true
+  );
+
+  const field_map = {};
+  const custom_field = {};
+  fieldRows.forEach(r => {
+    if (r.field_type && r.field_type.toLowerCase() === 'custom') {
+      custom_field[r.src_field_key] = r.trg_field_key;
+    } else {
+      field_map[r.src_field_key] = r.trg_field_key;
+    }
+  });
+  if (Object.keys(custom_field).length) {
+    field_map.custom_field = custom_field;
+  }
+
+  const optionRows = execSql(
+    'SELECT src_value_key, trg_value_key, src_field, trg_field FROM mapping_user_fields_options',
+    true
+  );
+
+  const translation_map = {};
+  optionRows.forEach(r => {
+    if (!translation_map[r.src_field]) {
+      translation_map[r.src_field] = { destination_id: r.trg_field };
+    }
+    translation_map[r.src_field][r.src_value_key] = r.trg_value_key;
+  });
+
+  return { user: { field_map, translation_map } };
+}
+
+module.exports = { buildMapping };

--- a/node_app/package.json
+++ b/node_app/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "node_app",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary
- add Node.js backend using the sqlite3 CLI
- create an HTTP endpoint returning mapping JSON
- document how to run the new server
- ignore SQLite database files

## Testing
- `node node_app/index.js &` *(server starts)*
- `curl -s http://localhost:3000/mapping` *(returns empty JSON)*


------
https://chatgpt.com/codex/tasks/task_e_6887213d709c8322b1f9fab195f5f08d