### PR TITLE
Implement generic SQLite CRUD helper

### DIFF
--- a/nodeapp/db.js
+++ b/nodeapp/db.js
@@ -1,0 +1,62 @@
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+
+const db = new sqlite3.Database(path.join(__dirname, 'database.db'));
+
+function run(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.run(sql, params, function(err) {
+      if (err) return reject(err);
+      resolve(this);
+    });
+  });
+}
+
+function get(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.get(sql, params, (err, row) => {
+      if (err) return reject(err);
+      resolve(row);
+    });
+  });
+}
+
+function all(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.all(sql, params, (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows);
+    });
+  });
+}
+
+function insert(table, data) {
+  const keys = Object.keys(data);
+  const placeholders = keys.map(() => '?').join(', ');
+  const values = Object.values(data);
+  const sql = `INSERT INTO ${table} (${keys.join(', ')}) VALUES (${placeholders})`;
+  return run(sql, values).then(result => result.lastID);
+}
+
+function update(table, id, data, idField = 'id') {
+  const keys = Object.keys(data);
+  const assignments = keys.map(k => `${k} = ?`).join(', ');
+  const values = Object.values(data);
+  const sql = `UPDATE ${table} SET ${assignments} WHERE ${idField} = ?`;
+  return run(sql, [...values, id]);
+}
+
+function remove(table, id, idField = 'id') {
+  const sql = `DELETE FROM ${table} WHERE ${idField} = ?`;
+  return run(sql, [id]);
+}
+
+module.exports = {
+  db,
+  run,
+  get,
+  all,
+  insert,
+  update,
+  remove
+};

--- a/nodeapp/index.js
+++ b/nodeapp/index.js
@@ -1,0 +1,20 @@
+const { db } = require('./db');
+
+// Example: create tables if they do not exist
+const createUserTable = `CREATE TABLE IF NOT EXISTS users (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,
+  email TEXT UNIQUE NOT NULL
+)`;
+
+const createPostsTable = `CREATE TABLE IF NOT EXISTS posts (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER,
+  content TEXT,
+  FOREIGN KEY(user_id) REFERENCES users(id)
+)`;
+
+db.serialize(() => {
+  db.run(createUserTable);
+  db.run(createPostsTable);
+});

--- a/nodeapp/package.json
+++ b/nodeapp/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "node-sqlite-app",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "dependencies": {
+    "sqlite3": "^5.1.6"
+  }
+}


### PR DESCRIPTION
## Summary
- create new `nodeapp` folder
- add `db.js` with insert, update and delete functions for SQLite
- sample `index.js` demonstrates table creation
- package.json lists `sqlite3` dependency

## Testing
- `node index.js` *(fails: Cannot find module 'sqlite3' because dependencies are not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68872bd6bc608322b70e0adac6867779